### PR TITLE
HarmonyX priority fixes

### DIFF
--- a/RogueTechPerfFixes/Patches/H_EffectManager.cs
+++ b/RogueTechPerfFixes/Patches/H_EffectManager.cs
@@ -18,6 +18,8 @@ public static class H_EffectManager
             return Mod.Settings.Patch.Vanilla;
         }
 
+        // HarmonyX: Priority: Set to Last after CustomStatisticsEffects
+        [HarmonyPriority(Priority.Last)]
         public static void Postfix(Effect effect)
         {
             if (!_cache.TryGetValue(effect.Target, out var effects))
@@ -37,6 +39,8 @@ public static class H_EffectManager
             return Mod.Settings.Patch.Vanilla;
         }
 
+        // HarmonyX: Priority: Set to Last after CustomStatisticsEffects
+        [HarmonyPriority(Priority.Last)]
         public static void Postfix(Effect e)
         {
             if (_cache.TryGetValue(e.Target, out var effects))
@@ -54,6 +58,8 @@ public static class H_EffectManager
             return Mod.Settings.Patch.Vanilla;
         }
 
+        // HarmonyX: Priority: Set to Last after CustomStatisticsEffects
+        [HarmonyPriority(Priority.Last)]
         public static void Postfix(Effect e)
         {
             if (_cache.TryGetValue(e.Target, out var effects))
@@ -119,6 +125,9 @@ public static class H_EffectManager
             return Mod.Settings.Patch.Vanilla;
         }
 
+    
+        // HarmonyX: Priority: Set to Last after CustomStatisticsEffects
+        [HarmonyPriority(Priority.Last)]
         public static void Postfix(List<Effect> ___effects)
         {
             _cache.Clear();


### PR DESCRIPTION
### Notes
- Due to HarmonyX patch ordering fixes from updated ModTek, update known differences from BlueWind mod tool.
- This is in attempt to baseline changes from old to new ModTek and capture NREs and other bugs.
- Similar fixes and idea for fixes already attempted by @wmtorode 